### PR TITLE
Avoid keyword for archival procedure guidance

### DIFF
--- a/draft-wiggers-hbs-state.md
+++ b/draft-wiggers-hbs-state.md
@@ -321,7 +321,7 @@ availability and deliver a sufficiently resilient solution, all the while
 enforcing whatever security protocols and procedures were required.
 Unfortunately, stateful hash-based signatures introduce an additional
 constraint in that they need to ensure the state is never re-used. Hence,
-archival procedures used for traditional trust infrastructures MUST be
+archival procedures used for traditional trust infrastructures have to be
 amended/redesigned to be used as viable options.
 
 One of the most problematic aspects of providing a long-lived resilient


### PR DESCRIPTION
This document doesn't describe steps on how to update these procedures, and therefore shouldn't use the key word MUST in this context.